### PR TITLE
changed visibility of executeRefactoring in RefactoringTest to protected

### DIFF
--- a/ch.hsr.ifs.cdttesting/src/ch/hsr/ifs/cdttesting/cdttest/CDTTestingRefactoringTest.java
+++ b/ch.hsr.ifs.cdttesting/src/ch/hsr/ifs/cdttesting/cdttest/CDTTestingRefactoringTest.java
@@ -82,7 +82,7 @@ public abstract class CDTTestingRefactoringTest extends CDTTestingTest {
 		runRefactoringAndAssertFailure();
 	}
 
-	private void executeRefactoring(boolean expectedSuccess) throws Exception {
+	protected void executeRefactoring(boolean expectedSuccess) throws Exception {
 		Refactoring refactoring = createRefactoring();
 		RefactoringContext context;
 		if (refactoring instanceof CRefactoring) {


### PR DESCRIPTION
I need this to be able to run refactorings without providing an expected outcome, for example when I just want to test the RefactoringStatus after checkInitialiConditions()