### PR TITLE
Support modifying ProblemPreferences

### DIFF
--- a/ch.hsr.ifs.cdttesting/src/ch/hsr/ifs/cdttesting/cdttest/CDTTestingCodanCheckerTest.java
+++ b/ch.hsr.ifs.cdttesting/src/ch/hsr/ifs/cdttesting/cdttest/CDTTestingCodanCheckerTest.java
@@ -47,12 +47,15 @@ public abstract class CDTTestingCodanCheckerTest extends CDTTestingTest {
 		}
 		CodanRuntime.getInstance().getCheckersRegistry().updateProfile(cproject.getProject(), profile);
 	}
+	
+	protected void problemPreferenceSetup(RootProblemPreference preference) {}
 
 	private void enableCodanProblem(final CodanProblem codanProblem) {
 		final IProblemPreference preference = codanProblem.getPreference();
 		if (preference instanceof RootProblemPreference) {
 			final RootProblemPreference rootProblemPreference = (RootProblemPreference) preference;
 			rootProblemPreference.getLaunchModePreference().enableInLaunchModes(CheckerLaunchMode.RUN_ON_FULL_BUILD);
+			problemPreferenceSetup(rootProblemPreference);
 		}
 		codanProblem.setEnabled(true);
 	}


### PR DESCRIPTION
**Problem:**
_enableChecker()_ in CDTTestingCodanCheckerTest fetches the Workspace Profile (enables/disables Problems) and saves it into the Project Profile, which overrides previously modified preferences.
All directly before calling _runCodan()_ which executes the checkers.
(As far as I know the Workspace Profile is not modifiable by code...)

**Solution:**
Call an overrideable _problemPreferenceSetup_ in which the preferences can be modified before _runCodan()_ (from inside _enableCodanProblem_) as suggested by @tcorbat or @fmorgner 

**Open Question:**
Is CDTTestingCodanQuickfixTestWithPreferences (and CDTTestingRefactoringTestWithPreferences) also for ProblemPreferences?
If yes:
* how to use it?
* Why not for Checkers? 
* Provide this as alternative?

**Usage Reference for this PR:**
This PR enables this commit: https://git.hsr.ch/#changesetPanel;1xPxLSwBpM;4193cfb861619eb9eecf8607c649928590da400e;commit
in the CCGLadiator repository. (Request access from rbislin or kdiener via hsr mail)
